### PR TITLE
Disable old media field GraphQL fields by default.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/MediaAppContextSwitches.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/MediaAppContextSwitches.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace OrchardCore.Media;
+
+internal static class MediaAppContextSwitches
+{
+    private const string EnableLegacyMediaFieldGraphQLFieldsKey = "OrchardCore.Media.EnableLegacyMediaFieldGraphQLFields";
+
+    internal static bool EnableLegacyMediaFields => AppContext.TryGetSwitch(EnableLegacyMediaFieldGraphQLFieldsKey, out var enabled) && enabled;
+}

--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -342,6 +342,48 @@ You may have to adjust your GraphQL queries in that case.
 
 Additionally, the `GetAliases` method in the `IIndexAliasProvider` interface is now asynchronous and has been renamed to `GetAliasesAsync`. Implementations of this interface should be modified by updating the method signature and ensure they handle asynchronous operations correctly.
 
+#### Media fields
+
+The schema for media fields has been updated. Instead of separate lists for `fileNames`, `urls`, `paths`, and `mediatexts`, these fields are now grouped under a single `files` type to simplify data binding on the front end.
+
+Please update your existing queries as shown in the following example:
+
+Before:
+
+```json
+{
+  article {
+    contentItemId
+    image {
+      mediatexts(first: 10)
+      urls(first: 10)
+    }
+  }
+}
+```
+
+After:
+
+```json
+{
+  article {
+    contentItemId
+    image {
+      files(first: 10) {
+        mediaText
+        url
+      }
+    }
+  }
+}
+```
+
+A compatibility switch has been introduced to allow continued use of the old `fileNames`, `urls`, `paths`, and `mediatexts` fields. To restore the legacy fields, add the following AppContext switch to your startup class:
+
+```csharp
+AppContext.SetSwitch("OrchardCore.Media.EnableLegacyMediaFieldGraphQLFields", true);
+```
+
 ### Resource Management
 
 Previously the `<resources type="..." />` Razor tag helper and the `{% resources type: "..." %}` Liquid tag were only capable of handling a hard-coded set of resource definition types (`script`, `stylesheet`, etc). Now both can be extended with `IResourcesTagHelperProcessor` to run custom rendering logic. To make this possible, the `OrchardCore.ResourceManagement.TagHelpers.ResourceType` and `OrchardCore.Resources.Liquid.ResourcesTag.ResourceType` enums have been replaced with a common `OrchardCore.ResourceManagement.ResourceTagType`. It was renamed to avoid confusion with `ResourceDefinition.Type`. This change does not affect the uses of the Razor tag helper or the Liquid tag in templates of user projects, but it affects published releases such as NuGet packages. Any themes and modules that contain `<resources type="..." />` in a Razor file (e.g. _Layout.cshtml_) must be re-released to generate the updated `.cshtml.cs` files, because the old pre-compiled templates would throw `MissingMethodException`.


### PR DESCRIPTION
#15003 introduced a new GraphQL type `files` to group all media item properties together. However, the old fields were left intact, resulting in duplicated fields. This PR removes the old fields by default but provides a compatibility switch to restore them if needed.

As suggested by @sebastienros, I added an `AppContext` switch to handle this. However, this is the first time we're using an `AppContext` switch, as far as I can tell. We may need to discuss whether this is the best approach or if we should consider an alternative.

/cc @MikeAlhayek @Piedone @hyzx86